### PR TITLE
Perform invasive surgery on the playlist service.

### DIFF
--- a/services/playlist.adoc
+++ b/services/playlist.adoc
@@ -1,4 +1,5 @@
 = Playlist
+:FileLoad:    link:../features/fileload.adoc
 :Playlist:    link:../features/playlist.adoc
 :AutoAdvance: link:../features/playlist-autoadvance.adoc
 :TextItems:   link:../features/playlist-textitems.adoc
@@ -15,8 +16,8 @@ The playlist service uses the internal API to communicate both with
 the platform service above it, and the player service below.
 
 The playlist service exposes an API atop that of the player service,
-delegating any commands it doesn't understand downstream.  It adds
-the following requests to the interface:
+delegating any commands it doesn't understand or outright reject
+downstream.  It adds the following requests to the interface:
 
 * `enqueue` — Adds a file or text item into the playlist;
 * `dequeue` — Removes a file or text item from the playlist;
@@ -26,8 +27,10 @@ the following requests to the interface:
 
 For a playlist, `quit` also closes any underlying player in addition.
 
-In addition, it _removes_ the following player requests (should
-they be present):
+In addition, should the player implement {FileLoad}[`FileLoad`], the
+{Playlist}[`Playlist`] feature replaces its functionality in
+incompatible ways; said feature *should* be disabled.  Thus, the
+player should _reject_ the following player requests:
 
 * `load` — Replaced with `enqueue`;
 * `eject` — Replaced with `select` (with no arguments);
@@ -42,9 +45,10 @@ It also adds the following responses to those sent by the player:
 
 == Implemented Features
 
-The playlist *must* implement, as a minimum, the {Playlist}[`Playlist`],
-{TextItems}[`Playlist.TextItems`], and
-{AutoAdvance}[`Playlist.AutoAdvance`] features.
+The playlist *must* implement, as a minimum, the
+{Playlist}[`Playlist`] and {AutoAdvance}[`Playlist.AutoAdvance`]
+features.  It is recommended, but not critical, to implement
+{TextItems}[`Playlist.TextItems`].
 
 == Requirements
 


### PR DESCRIPTION
TextItems is now not required, and the definition of the service's
behaviour with regards to the FileLoad feature is clearer.
