### PR TITLE
Begin work on specifying External API resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 _book/
 
 *.sw?
+*.sublime-workspace
+*.sublime-project

--- a/GLOSSARY.adoc
+++ b/GLOSSARY.adoc
@@ -28,6 +28,10 @@ A program that provides services.
 A specific role in the BAPS3 system, usually defined as a group of expected
 features.
 
+== simple compound resource
+A resource that relays requests to each of its child resources, and
+aggregates the results.
+
 == player service
 The service responsible for playing single audio tracks.
 

--- a/SUMMARY.adoc
+++ b/SUMMARY.adoc
@@ -18,6 +18,7 @@
 ... link:comms/internal/protocol.adoc[Protocol]
 ... link:comms/internal/changes.adoc[API Changes]
 .. link:comms/external/README.adoc[External API]
+... link:comms/external/composites.adoc[Composite Resources]
 . link:features/README.adoc[Features]
 .. link:features/core.adoc[Core]
 .. link:features/fileload.adoc[FileLoad]

--- a/comms/external/composites.adoc
+++ b/comms/external/composites.adoc
@@ -1,0 +1,31 @@
+= Composite Resources
+:RFC6902: http://www.ietf.org/rfc/rfc6902.txt
+
+Many of the resources specified for the external API serve no purpose
+but to contain other, more specific resources.  These _composite
+resources_ usually collect a group of resources related by feature,
+service, or ownership.
+
+== Simple composite resources
+
+To shorten the specification, we often describe a resource's behaviour
+under some or all methods as being 'as a simple composite resource'.
+Informally, this means that actions distribute over the children of
+the resource.  More specifically:
+
+* The `GET` representation of the resource *should* be an object whose
+  keys are the names of resource children the client has authorisation
+  to `GET`, and whose corresponding values are the `GET`
+  representations of said children;
+* A `PUT` action, with a payload consisting of an object of child
+  representations as described above, *should* be equivalent to a
+  `PUT` for each child present in the object (with its intended new
+  representation), and a `DELETE` for each absent child;
+* A `PATCH` action *may* be accepted, provided it follows
+  {RFC6902}[RFC 6902]: the behaviours of the `add`, `remove`, and
+  `replace` operations *should* then map onto `PUT`, `DELETE`, and
+  `PUT` (to an existing resource) respectively;
+* A `POST` action *should* always fail, as no new resources can be
+  added.
+
+Other actions *should not* be added.

--- a/features/core.adoc
+++ b/features/core.adoc
@@ -197,12 +197,16 @@ External API endpoints upon starting to exit.
 
 === `PUT`
 
-Attempts to set the state to the given state.  The state payload *must* be a string, and *should* be interpreted in a case-insensitive manner.
+Attempts to set the state to the given state.  The state payload
+*must* be a string, and *should* be interpreted in a case-insensitive
+manner.
 
-Any unknown states, or malformed payloads, *should* result in a malformed value error.
+Any unknown states, or malformed payloads, *should* result in a
+malformed value error.
 
-access
-The semantics of each state is specified alongside the documentation for the feature introducing that state.  The semantics of the two core states are as follows:
+access The semantics of each state is specified alongside the
+documentation for the feature introducing that state.  The semantics
+of the two core states are as follows:
 
 ==== `Ready`
 
@@ -210,7 +214,8 @@ Services *should* reject an attempt to set the state to `Ready`.
 
 ==== `Quitting`
 
-Services *should* interpret this as equivalent to a `QUIT` Internal API request.
+Services *should* interpret this as equivalent to a `QUIT` Internal
+API request.
 
 === `DELETE`
 

--- a/features/core.adoc
+++ b/features/core.adoc
@@ -177,14 +177,14 @@ If a service provides `FEATURES PlayStop FileLoad End`, the `GET`
 response value for `/info/features` *may* be `["PlayStop", "FileLoad",
 "End"]` (or any permutation thereof).
 
-=== `/ctl`
+=== `/control`
 
 The _control resource_, which contains _writable flags_ that affect
 the service's running and configuration.
 
 Behaves as a simple composite resource for all actions.
 
-=== `/ctl/state`
+=== `/control/state`
 
 The current state of this service.
 

--- a/features/core.adoc
+++ b/features/core.adoc
@@ -127,3 +127,90 @@ as the third and later words of the `WHAT` response.
 The second word of the `WHAT` response is a human-readable error
 message.  Future revisions of the spec *may* define a structure for
 this error message.
+
+== Resources
+
+=== `/`
+
+The _root resource_.  Every resource is a descendant of this resource.
+
+Behaves as a simple composite resource for all actions.
+
+=== `/info`
+
+The _information resource_, which contains _read-only_ information
+about the _service itself_.
+
+Behaves as a simple composite resource for `GET`.  All other actions
+are forbidden.
+
+=== `/info/serverid`
+
+Contains the server identifier that would be returned by the `OHAI`
+Internal API response.
+
+All actions apart from `GET` are forbidden.
+
+==== Example
+
+If a service identifies as `OHAI listd-0.3.0/playd-0.3.0`, then the
+`GET` response value for `/info/serverid` shall be
+`"listd-0.3.0/playd-0.3.0"`.
+
+=== `/info/features`
+
+Contains a list of strings representing the implemented features on
+the queried service (those returned by a `FEATURES` Internal API
+response from this service).
+
+All actions apart from `GET` are forbidden.
+
+=== `GET`
+
+`GET` responses *must* return a list of strings that correspond
+exactly to the names of the features implemented by the queried
+service.  There is _no_ defined ordering on the strings.
+
+==== Example
+
+If a service provides `FEATURES PlayStop FileLoad End`, the `GET`
+response value for `/info/features` *may* be `["PlayStop", "FileLoad",
+"End"]` (or any permutation thereof).
+
+=== `/ctl`
+
+The _control resource_, which contains _writable flags_ that affect
+the service's running and configuration.
+
+Behaves as a simple composite resource for all actions.
+
+=== `/ctl/running`
+
+Whether the server is, or should be, running.
+
+Due to the obvious denial-of-service attack vector presented via
+unauthorised access to this control point, services *should* forbid
+non-`GET` access to `/ctl/running` unless explicitly required and a
+strong authentication mechanism is available to restrict said
+privilege.
+
+=== `GET`
+
+`GET` requests *should* return a Boolean: `false` if the service is
+known to be shutting down, and `true` otherwise.  Generally, this will
+be the latter, as non-running services will likely close their
+External API endpoints upon starting to exit.
+
+=== `PUT`
+
+If the payload value is `true`, the service *should* regard the
+request as a successful no-operation.
+
+If the payload value is `false`, the service *should* regard the
+request as equivalent to a `quit` Internal API request.
+
+Any other payload values *should* result in a malformed value error.
+
+=== `DELETE`
+
+Behaves as a `PUT` with the payload value `false`.

--- a/features/core.adoc
+++ b/features/core.adoc
@@ -184,15 +184,9 @@ the service's running and configuration.
 
 Behaves as a simple composite resource for all actions.
 
-=== `/ctl/running`
+=== `/ctl/state`
 
-Whether the server is, or should be, running.
-
-Due to the obvious denial-of-service attack vector presented via
-unauthorised access to this control point, services *should* forbid
-non-`GET` access to `/ctl/running` unless explicitly required and a
-strong authentication mechanism is available to restrict said
-privilege.
+The current state of this service.
 
 === `GET`
 
@@ -203,14 +197,21 @@ External API endpoints upon starting to exit.
 
 === `PUT`
 
-If the payload value is `true`, the service *should* regard the
-request as a successful no-operation.
+Attempts to set the state to the given state.  The state payload *must* be a string, and *should* be interpreted in a case-insensitive manner.
 
-If the payload value is `false`, the service *should* regard the
-request as equivalent to a `quit` Internal API request.
+Any unknown states, or malformed payloads, *should* result in a malformed value error.
 
-Any other payload values *should* result in a malformed value error.
+access
+The semantics of each state is specified alongside the documentation for the feature introducing that state.  The semantics of the two core states are as follows:
+
+==== `Ready`
+
+Services *should* reject an attempt to set the state to `Ready`.
+
+==== `Quitting`
+
+Services *should* interpret this as equivalent to a `QUIT` Internal API request.
 
 === `DELETE`
 
-Behaves as a `PUT` with the payload value `false`.
+Behaves as a `PUT` with the payload value `Quitting`.

--- a/features/core.adoc
+++ b/features/core.adoc
@@ -136,28 +136,15 @@ The _root resource_.  Every resource is a descendant of this resource.
 
 Behaves as a simple composite resource for all actions.
 
-=== `/info`
+=== `/control`
 
-The _information resource_, which contains _read-only_ information
-about the _service itself_.
+The _control resource_, which contains both _read-only_ information
+about the service, and _writable flags_ that affect the service's
+running and configuration.
 
-Behaves as a simple composite resource for `GET`.  All other actions
-are forbidden.
+Behaves as a simple composite resource for all actions.
 
-=== `/info/serverid`
-
-Contains the server identifier that would be returned by the `OHAI`
-Internal API response.
-
-All actions apart from `GET` are forbidden.
-
-==== Example
-
-If a service identifies as `OHAI listd-0.3.0/playd-0.3.0`, then the
-`GET` response value for `/info/serverid` shall be
-`"listd-0.3.0/playd-0.3.0"`.
-
-=== `/info/features`
+=== `/control/features`
 
 Contains a list of strings representing the implemented features on
 the queried service (those returned by a `FEATURES` Internal API
@@ -174,15 +161,21 @@ service.  There is _no_ defined ordering on the strings.
 ==== Example
 
 If a service provides `FEATURES PlayStop FileLoad End`, the `GET`
-response value for `/info/features` *may* be `["PlayStop", "FileLoad",
-"End"]` (or any permutation thereof).
+response value for `/control/features` *may* be `["PlayStop",
+"FileLoad", "End"]` (or any permutation thereof).
 
-=== `/control`
+=== `/control/serverid`
 
-The _control resource_, which contains _writable flags_ that affect
-the service's running and configuration.
+Contains the server identifier that would be returned by the `OHAI`
+Internal API response.
 
-Behaves as a simple composite resource for all actions.
+All actions apart from `GET` are forbidden.
+
+==== Example
+
+If a service identifies as `OHAI listd-0.3.0/playd-0.3.0`, then the
+`GET` response value for `/control/serverid` shall be
+`"listd-0.3.0/playd-0.3.0"`.
 
 === `/control/state`
 

--- a/features/fileload.adoc
+++ b/features/fileload.adoc
@@ -80,6 +80,6 @@ Given the nil payload, this *should* behave as equivalent to an `eject` request.
 
 As `PUT` with the nil payload.
 
-=== `/ctl/state` (additional state)
+=== `/control/state` (additional state)
 
 Provides the `Ejected` state.  Attempts to `PUT` the state to `Ejected` *should* behave in a manner equivalent to the `eject` Internal API request.

--- a/features/fileload.adoc
+++ b/features/fileload.adoc
@@ -55,3 +55,31 @@ If the load failed, the state *should* be set to `Ejected`.
 * A new upstream connects to a server with the `FileLoad` feature,
   as part of the _initial responses_; *or*
 * A new file has been loaded.
+
+== Resources
+
+=== `/player`
+
+Resource group for player-related resources.  Behaves as a simple composite resource.  If defined in other features, treat as if singly defined.
+
+=== `/player/file`
+
+The currently loaded file.
+
+==== `GET`
+
+The `GET` representation *should* be equivalent to the file path announced in the latest `FILE` response (if the state is not `Ejected`), or `nil` if there is no file loaded (the state is `Ejected`).  The value when the state is `Quitting` is undefined.
+
+==== `PUT`
+
+Given a string payload, this *should* behave as equivalent to the `load` Internal API request with the given string as the file path.
+
+Given the nil payload, this *should* behave as equivalent to an `eject` request.
+
+==== `DELETE`
+
+As `PUT` with the nil payload.
+
+=== `/ctl/state` (additional state)
+
+Provides the `Ejected` state.  Attempts to `PUT` the state to `Ejected` *should* behave in a manner equivalent to the `eject` Internal API request.

--- a/features/seek.adoc
+++ b/features/seek.adoc
@@ -32,3 +32,29 @@ to `MICROS`.  If the position is past the end of audio, the server
 
 The new position *may* be reported, for example via the `TIME`
 response, but this is outside the scope of this feature.
+
+== Resources
+
+=== `/player`
+
+Resource group for player-related resources.  Behaves as a simple composite resource.  If defined in other features, treat as if singly defined.
+
+=== `/player/position`
+
+The current position within the audio.
+
+==== `GET`
+
+Unless defined otherwise in other implemented features, the server *must* respond to `GET` with the nil payload.
+
+==== `PUT`
+
+Given an integral payload, this *should* behave as equivalent to the `seek` Internal API request with the given integer as the new microsecond position.
+
+Given the nil payload, this *should* behave as if 0 was supplied.
+
+Other payloads, including string representations of numbers, *should* be rejected.
+
+==== `DELETE`
+
+As `PUT` with the nil payload.


### PR DESCRIPTION
This adds some initial attempts to specify resources for Core and Playlist-service features.  This will likely need _extensive_ copy-editing and feedback, so please **do not** merge this without really looking at and questioning it.
