### PR TITLE
Weaken, but also clarify. SELECT definition.

### DIFF
--- a/features/playlist.adoc
+++ b/features/playlist.adoc
@@ -227,6 +227,11 @@ With an index and hash, the item at index `INDEX` and hash `HASH`
 is selected.  Playback controls *should* work, and the state *should
 not* be `Ejected`.
 
+This response *must* be sent when the selection changes or is cleared,
+and also *must* be sent as an _initial response_. It *may* also be
+sent at any other time, so long as its information is correct at time
+of sending.
+
 == Item Types
 
 === `file`

--- a/services/playlist.adoc
+++ b/services/playlist.adoc
@@ -39,7 +39,7 @@ It also adds the following responses to those sent by the player:
 
 * `ENQUEUE` — An item has been enqueued;
 * `DEQUEUE` — An item has been dequeued;
-* `SELECT` — The selection has been changed;
+* `SELECT` — The current selected item, or lack thereof;
 * `COUNT` — The current number of items in the playlist;
 * `ITEM` — A playlist item.
 


### PR DESCRIPTION
Allow clients to send `SELECT` when they want to.  Ensure they always send `SELECT` when they have to.
