### PR TITLE
Rewriting the internal protocol spec

### DIFF
--- a/comms/internal/protocol.adoc
+++ b/comms/internal/protocol.adoc
@@ -51,7 +51,7 @@ run, is ok.
 == Overview
 
 The Internal API protocol uses the concept of linefeed-delimited
-_commands_, each consisting of zero or more whitespace-delimited
+_commands_, each consisting of one or more whitespace-delimited
 _words_.  Each word consists of a sequence of bytes (usually
 representing UTF-8 characters).
 

--- a/comms/internal/protocol.adoc
+++ b/comms/internal/protocol.adoc
@@ -114,9 +114,7 @@ emitted verbatim.
 The internal API protocol adheres to the following BNF grammar:
 
 --------
-<command>     ::= "\n"
-               |  <whitespace> "\n"
-               |  <words> "\n"
+<command>     ::= <words> "\n"
                |  <whitespace> <words> "\n"
                |  <words> <whitespace> "\n"
                |  <whitespace> <words> <whitespace> "\n"
@@ -155,6 +153,9 @@ The internal API protocol adheres to the following BNF grammar:
 Each distinct `word` and `command` production denotes a separate word
 and command respectively.  Any `normal-char`, `double-char`,
 `single-char`, or `any-char` is emitted verbatim in its word.
+
+Syntax errors (for example, a line containing no words) *must* cause a
+`WHAT` response to be sent.
 
 Escape sequences in the above BNF may be interpreted as follows:
 [cols="1,1,2", options="header"]

--- a/comms/internal/protocol.adoc
+++ b/comms/internal/protocol.adoc
@@ -96,9 +96,9 @@ emitted verbatim.
 |`"`
 
 |`\` (0x5C)
-|Begins backslash escape for next character only
+|Begins backslash escape for next byte only
 |`\`
-|Begins backslash escape for next character only
+|Begins backslash escape for next byte only
 |`\`
 
 |Any other byte 'b'

--- a/comms/internal/protocol.adoc
+++ b/comms/internal/protocol.adoc
@@ -30,119 +30,164 @@ need this luxury.
 
 The internal API is designed to expect requests and responses in
 the {UTF-8}[UTF-8] encoding.  However, to allow simple implementations
-that operate on a per-byte level, certain uses of UTF-8 beyond the
-single-byte (ASCII) range are discouraged.
+that operate on a per-byte level, all characters with special meaning
+are taken from the single-byte UTF-8 subset (that is, ASCII).  In
+addition, the backslash-escape mechanism (see below) operates only on
+one byte.
 
 API users *must* support the sending and receiving of all single-byte
 UTF-8 character codes (that is, ASCII), and *should* support the
 sending and receiving of the full UTF-8 range subject to the
 limitations below.
 
-=== Limitations
+While a message is in transit, API users *must not* alter its bytes in
+any way other than changing between equivalent quoting, escaping and
+line/word-delimiting forms.  This includes correcting, omitting, or
+replacing any non-UTF-8 byte sequences, as well as case folding or
+normalising.  However, changing from double quotes to single quotes, or
+introducing or removing more whitespace to an inter-word whitespace
+run, is ok.
 
-It is _undefined behaviour_ to:
+== Overview
 
-* Use a whitespace character not in the single-byte subset of UTF-8
-  to separate words.  (See below for recommendations on
-  word-separating whitespace.)  This limitation allows implementations
-  to make use of single-byte whitespace checks for word separation;
-* Backslash-escape a character not in single-byte UTF-8.  (This
-  should not be necessary, as single- and double-quote modes will
-  allow these characters to be used without escape.)  This limitation
-  allows backslash escaping to operate on a single-byte level;
-* Backslash-escape the line-feed character.  This limitation is due
-  to the special status of line-feed escaping as line continuation in
-  shell tokenisation, and may change in future when a decision is made
-  as to the necessity of keeping this status in the API.
+The Internal API protocol uses the concept of linefeed-delimited
+_commands_, each consisting of zero or more whitespace-delimited
+_words_.  Each word consists of a sequence of bytes (usually
+representing UTF-8 characters).
 
-API users *may* make decisions as to how to interpret said undefined
-behaviour, but *should not* expect certain behaviour from other
-users without consulting the `FEATURES` flags and `OHAI` response
-for confirmation of said behaviour.
+=== Quoting and escaping
+To allow all byte sequences to be represented in words, the protocol
+uses several quoting and escaping strategies, which are summarised in
+the below table and formalised later.
 
-== Quoting and Escaping
+Note that, while each quoting mechanism lasts until the matching (and
+non-backslash-escaped) quote is found, backslash-escape affects only
+the following byte (then, the previous quoting behaviour returns
+afterwards).
 
-Most characters may be transmitted verbatim via the protocol.
-However, in order to allow separation of protocol communications
-into the _words_ and _commands_ defined below, BAPS3 gives special
-meaning to certain characters.  This is done according to four
-_quote modes_, specified below.
+Also note that backslash-escape only escapes the next _byte_: for this
+reason, clients and services *should not* backslash-escape multi-byte
+UTF-8 characters (such treatment is unnecessary, as all special
+characters are single-byte).
 
-NOTE: In case of ambiguity, refer to the {shell}[POSIX shell] quoting
-standards: we follow that style of quoting with the exception of
-disallowing variable and command interpolation (thus, backtick and
-dollar are not considered special).
+Finally, backslashes *must not* be interpreted as starting an escape
+while in backslash-escape or double-quoted modes, and *must* be
+emitted verbatim.
 
-=== Unquoted mode
+[cols="1,1,1,1,1", options="header"]
+.Quoting and escaping strategies
+|===
+|Character
+|Meaning when unquoted
+|Meaning when single-quoted
+|Meaning when double-quoted
+|Meaning when backslash-escaped
 
-A protocol tokeniser *should* start in _unquoted_ mode.  In this
-mode:
+|`'` (0x27)
+|Begins single-quoted mode
+|Begins unquoted mode
+|`'`
+|`'`
 
-* Any run of _whitespace characters_ (see below) separates one word
-  from the next;
-* A _line-feed_ character (`0x0A`) separates one command from the
-  next, and ends any word preceding;
-* A single-quote character (`'`) begins _single-quoted_ mode;
-* A double-quote character (`"`) begins _double-quoted_ mode;
-* A backslash character (`\`) begins _escaped_ mode;
-* Any other character is echoed verbatim.
+|`"` (0x22)
+|Begins double-quoted mode
+|`"`
+|Ends double-quoted mode
+|`"`
 
-==== Whitespace
+|`\` (0x5C)
+|Begins backslash escape for next character only
+|`\`
+|Begins backslash escape for next character only
+|`\`
 
-The whitespace characters permitted for word separation *must not*
-contain line-feed (`0x0A`), and *must* contain space (`0x20`) and
-horizontal tab (`0x09`).  Consequently, API users *should* use the
-latter two characters for word separation.  API users *should not*
-use multi-byte whitespace characters, for the reasons provided in
-_Encoding_.
+|Any other byte 'b'
+|'b'
+|'b'
+|'b'
+|'b'
+|===
 
-For implementations in C or C++, the C function {isspace}[isspace()]
-*may* be used to identify word-separating whitespace, so long as
-line-feed is not interpreted as such.
 
-=== Single-quoted mode
+== Formal Specification
 
-In single-quoted mode, only the single-quote character is treated
-specially, and has the effect of returning to unquoted mode.
+The internal API protocol adheres to the following BNF grammar:
 
-=== Double-quoted mode
+--------
+<command>     ::= "\n"
+               |  <whitespace> "\n"
+               |  <words> "\n"
+               |  <whitespace> <words> "\n"
+               |  <words> <whitespace> "\n"
+               |  <whitespace> <words> <whitespace> "\n"
 
-In double-quoted mode:
+<words>       ::= <word>
+               |  <word> <whitespace> <words>
 
-* A backslash character begins escaped mode;
-* A double-quote character begins unquoted mode;
-* Any other character is echoed verbatim.
+<word>        ::= "'" <single>
+               |  "'" <single> <word>
+               |  "\"" <double>
+               |  "\"" <double> <word>
+               | <escape>
+               | <escape> <word>
+               | <normal-char>
+               | <normal-char> <word>
 
-### Escaped mode
+<single>      ::= "'"
+               |  <single-char> <single>
 
-In escaped mode, any single character is treated verbatim; the mode
-then reverts to that in which the backslash beginning escaped mode
-was read.
+<double>      ::= "\""
+               |  <escape> <double>
+               |  <double-char> <double>
 
-To allow implementations which escape single bytes instead of
-characters, clients *should not* expect servers to backslash-escape
-multiple-byte characters properly, and *should* instead use
-single-quoted or double-quoted mode to escape these characters.
+<whitespace>  ::= <ws-char>
+               |  <ws-char> <whitespace>
 
-== Words
+<escape>      ::= "\\" <any-char>
 
-The main protocol element is the _word_, which is a _well-formed_
-sequence of one or more raw characters delimited by any non-zero run
-of _unquoted_ whitespace.  A _well-formed_ word is one that ends in
-unquoted mode (quotes must be matched), and does not end with a
-backslash.
+<ws-char>     ::= " " | "\t" | "\v" | "\f" | "\r"
+<normal-char> ::= (any byte not in <ws-char> or one of " ' \ \n)
+<double-char> ::= (any byte except one of " \)
+<single-char> ::= (any byte except ')
+<any-char>    ::= (any byte)
+--------
 
-By _raw_ characters, we mean that the criteria for a valid word hold
-_before_ tokenisation, and specifically that the special characters
-count towards the one-or-more limit.  This means that, while the empty
-string is _not_ a valid word, the quoted 'empty' string `''` is.
-Implicitly, the unquoted whitespace characters are not considered to
-count towards any words.
+Each distinct `word` and `command` production denotes a separate word
+and command respectively.  Any `normal-char`, `double-char`,
+`single-char`, or `any-char` is emitted verbatim in its word.
 
-NOTE: There is _no_ limit on the number of quote mode transitions
-inside a single word.  For example, `unquoted"double"unquoted'single'\
-unquoted` *should* be considered one word (albeit a pathological
-one).
+Escape sequences in the above BNF may be interpreted as follows:
+[cols="1,1,2", options="header"]
+.BNF escape sequences
+|===
+|Sequence
+|Byte
+|Meaning
+
+|`\t`
+|`0x09`
+|Horizontal tab
+
+|`\n`
+|`0x0A`
+|Line feed
+
+|`\v`
+|`0x0B`
+|Vertical tab
+
+|`\f`
+|`0x0C`
+|Form feed
+
+|`\r`
+|`0x0B`
+|Carriage return
+
+|`\\`
+|`0x5C`
+|Backslash
+|===
 
 == Commands
 

--- a/tests/internal.adoc
+++ b/tests/internal.adoc
@@ -134,9 +134,9 @@ the source.
 for example in Go)
 
 |U2
-|`"f\xfcr\n"`
-|`{"f\xef\xbf\xbdr"}`
-|Invalid UTF-8 (ISO-8859-1, using Go syntax)
+|N/A
+|N/A
+|This ID was used for a test which is no longer in use.
 
 |X1
 |`"enqueue file \"C:\\\\Users\\\\Test\\\\Artist - Title.mp3\" 1\n"`


### PR DESCRIPTION
This is an attempt to make the internal protocol spec more formal and prescriptive.  Specifically, this tries to:
- Replace most of the text with a BNF of the intended internal protocol;
- Make it obvious that the protocol, while intended to be used with UTF-8, doesn't actually care much what goes through it, and the escaping logic should only work on a per-byte level;
- Pave the way for removing test U2 (something I should probably add to this prq).

Comments welcome.  Do _not_ merge without reading and checking!
